### PR TITLE
chore: Disable Docker Compose setup for APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,10 @@ $ docker-compose up # Start Kong
 $ cd products-api && npm run start:local # Start Products API - Soon we'll move this to Docker Compose too
 $ cd cart-api && npm run start:local # Start Cart API - Soon we'll move this to Docker Compose too
 ```
+
+Once all services are running, open your browser and do:
+
+```bash
+GET http://localhost:8000/product
+GET http://localhost:8000/cart
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,16 +18,16 @@ services:
       - "127.0.0.1:8001:8001"
       - "127.0.0.1:8444:8444"
 
-  products-api:
-    build:
-      context: ./products-api
-      dockerfile: ./docker/Dockerfile
-    ports:
-      - "3001:3001"
+  # products-api:
+  #   build:
+  #     context: ./products-api
+  #     dockerfile: ./docker/Dockerfile
+  #   ports:
+  #     - "3001:3001"
 
-  carts-api:
-    build:
-      context: ./carts-api
-      dockerfile: ./docker/Dockerfile
-    ports:
-      - "3002:3002"
+  # carts-api:
+  #   build:
+  #     context: ./carts-api
+  #     dockerfile: ./docker/Dockerfile
+  #   ports:
+  #     - "3002:3002"

--- a/kong.yml
+++ b/kong.yml
@@ -2,13 +2,15 @@ _format_version: "3.0"
 
 services:
 - name: products-api-service
-  url: http://products-api:3001
+  # url: http://products-api:3001
+  url: http://host.docker.internal:3001
   routes:
   - name: products-api-router
     paths:
       - /product
 - name: carts-api-service
-  url: http://carts-api:3002
+  # url: http://carts-api:3002
+  url: http://host.docker.internal:3002
   routes:
   - name: carts-api-router
     paths:


### PR DESCRIPTION
This is temporary. We'll soon get the Docker & Docker Compose setup for APIs. For now, it's causing issues.