### PR TITLE
chore: Setup scripts so Cloud Run can use the right Carts API image

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,19 @@ GET http://localhost:8000/product
 GET http://localhost:8000/cart
 ```
 
-### Applying Terraform
+### Deploying new versions
 
 > Before you apply Terraform, you may need to enable a few Google Cloud APIs, including Cloud Run Admin API, API Gateway API, etc.
 
 First, ensure you have a Service Account key. Contact the administrator. Save it in the root folder as `service-account.json`.
 
 ```bash
+# Ensure you're at the root folder.
+cd terraform-starter
+
+# Deploy (Build & Publish) the Docker images
+$ ./scripts/deploy-image.sh
+
+# Apply Terraform
 $ terraform apply
 ```

--- a/README.md
+++ b/README.md
@@ -42,17 +42,24 @@ GET http://localhost:8000/cart
 
 ### Deploying new versions
 
-> Before you apply Terraform, you may need to enable a few Google Cloud APIs, including Cloud Run Admin API, API Gateway API, etc.
+> You may need to manually enable a few GCP APIs, including Cloud Run Admin API, API Gateway API, etc, as we're not managing these on Terraform yet.
 
 First, ensure you have a Service Account key. Contact the administrator. Save it to `terraform/gcp-service-account.json`.
 
 ```bash
-# Ensure you're at the root folder.
+# 1. Ensure you're at the root folder.
 cd terraform-starter
 
-# Deploy (Build & Publish) the Docker images
-$ ./scripts/deploy-image.sh
+# 2. Deploy (Build & Publish) the Docker images
+$ ./scripts/deploy-image.sh carts-api 1.0.1
 
-# Apply Terraform
+# 3. Change your Terraform image, so it points to the image tag you just published
+# TODO: Get rid of this manual step, and deploy a new revision from CI on every new tag.
+containers {
+  image = "docker.io/stanleysathler/terraform-starter-carts-api:1.0.1"
+  ...
+}
+
+# 4. Apply Terraform
 $ terraform apply
 ```

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ GET http://localhost:8000/cart
 
 > Before you apply Terraform, you may need to enable a few Google Cloud APIs, including Cloud Run Admin API, API Gateway API, etc.
 
-First, ensure you have a Service Account key. Contact the administrator. Save it in the root folder as `service-account.json`.
+First, ensure you have a Service Account key. Contact the administrator. Save it to `terraform/gcp-service-account.json`.
 
 ```bash
 # Ensure you're at the root folder.

--- a/carts-api/src/index.ts
+++ b/carts-api/src/index.ts
@@ -1,7 +1,7 @@
 import { setupApp } from "./utils";
 
-const PORT = 3002;
-const HOST = "::"; // This is required for Docker environments
+const PORT = Number.parseInt(process.env.PORT ?? "3003"); // Cloud Run requires you to use `process.env.PORT` as it assigns a random port.
+const HOST = "::"; // This is required for Docker environments.
 
 /*
  * Start server.

--- a/carts-api/src/index.ts
+++ b/carts-api/src/index.ts
@@ -1,6 +1,6 @@
 import { setupApp } from "./utils";
 
-const PORT = Number.parseInt(process.env.PORT ?? "3003"); // Cloud Run requires you to use `process.env.PORT` as it assigns a random port.
+const PORT = Number.parseInt(process.env.PORT ?? "3003"); // Cloud Run requires you to use `process.env.PORT`.
 const HOST = "::"; // This is required for Docker environments.
 
 /*

--- a/scripts/deploy-image.sh
+++ b/scripts/deploy-image.sh
@@ -13,7 +13,7 @@ tag="$2"
 docker buildx create --name terraform-starter-builder --bootstrap --use
 
 # Build Docker image. 
-# Docker Buildx, because we're building from MacOS (arm64) but for Cloud Run (amd64)
+# Docker Buildx, as we need multi-platform builds - we're building from MacOS (arm64) but for Cloud Run (amd64)
 docker buildx build \
     --push \
     --platform linux/amd64,linux/arm64 \

--- a/scripts/deploy-image.sh
+++ b/scripts/deploy-image.sh
@@ -9,15 +9,15 @@ fi
 service_name="$1"
 tag="$2"
 
-# Build Docker image ---- docker build -t <image-name> -f <dockerfile-path> <context-path>
-echo "[+] Building image..."
-docker build -t stanleysathler/terraform-starter-$service_name:$tag -f $service_name/docker/Dockerfile $service_name # Note the image must contain our Docker username must be in this format
+# Setup buildx 
+docker buildx create --name terraform-starter-builder --bootstrap --use
 
-# Publish Docker image
-echo "[+] Publishing image..."
-docker push stanleysathler/terraform-starter-$service_name:$tag # Note the image must contain our Docker username and must be in this format
-
-# Publishing a `latest` alias
-echo "[+] Publishing latest alias..."
-docker tag stanleysathler/terraform-starter-$service_name:$tag stanleysathler/terraform-starter-$service_name:latest
-docker push stanleysathler/terraform-starter-$service_name:latest
+# Build Docker image. 
+# Docker Buildx, because we're building from MacOS (arm64) but for Cloud Run (amd64)
+docker buildx build \
+    --push \
+    --platform linux/amd64,linux/arm64 \
+    --tag stanleysathler/terraform-starter-$service_name:$tag \
+    --tag stanleysathler/terraform-starter-$service_name:latest \
+    --file $service_name/docker/Dockerfile \
+    $service_name

--- a/scripts/deploy-image.sh
+++ b/scripts/deploy-image.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Check if service_name argument is provided
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <service_name> <tag>"
+    exit 1
+fi
+
+service_name="$1"
+tag="$2"
+
+# Build Docker image ---- docker build -t <image-name> -f <dockerfile-path> <context-path>
+echo "[+] Building image..."
+docker build -t stanleysathler/terraform-starter-$service_name:$tag -f $service_name/docker/Dockerfile $service_name # Note the image must contain our Docker username must be in this format
+
+# Publish Docker image
+echo "[+] Publishing image..."
+docker push stanleysathler/terraform-starter-$service_name:$tag # Note the image must contain our Docker username and must be in this format
+
+# Publishing a `latest` alias
+echo "[+] Publishing latest alias..."
+docker tag stanleysathler/terraform-starter-$service_name:$tag stanleysathler/terraform-starter-$service_name:latest
+docker push stanleysathler/terraform-starter-$service_name:latest

--- a/scripts/run-app.sh
+++ b/scripts/run-app.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Check if service_name argument is provided
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <service_name>"
+    exit 1
+fi
+
+service_name="$1"
+
+# Build Docker image. 
+docker build \
+  -t stanleysathler/terraform-starter-$service_name:dev \
+  -f $service_name/docker/Dockerfile \
+  $service_name
+
+# Remove previous container
+docker rm -f terraform-starter-$service_name || true
+
+# Run container with that image
+docker run \
+  -p 3000:8080 \
+  -e PORT=8080 \
+  --name terraform-starter-$service_name \
+  stanleysathler/terraform-starter-$service_name:dev

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -48,7 +48,7 @@ resource "google_cloud_run_v2_service" "carts-api" {
     }
 
     containers {
-      image = "gcr.io/cloudrun/hello"
+      image = "docker.io/stanleysathler/terraform-starter-carts-api:1.0.1" # We can't always use `latest` - file must be changed so Terraform does a new deploy.
       resources {
         cpu_idle = true
         limits = {


### PR DESCRIPTION
So far, we're using GCP's "Hello" image we got from their docs. Now we must change it so that our Cloud Runs use the proper Docker images.

### Checklist

- [x] Setup scripts to build and publish Docker image
- [x] Setup multi-platform builds, as we can't run arm64 images on Cloud Run (they need to be amd64)